### PR TITLE
updates to webpack and package.json to target `dist/index.min.js` instead of `src/`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
     "deploy-storybook": "storybook-to-ghpages",
     "test-ci": "jest --coverage && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"
   },
+  "files": [
+    "dist"
+  ],
   "keywords": [
     "react",
     "alerts",

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "react-alerts-lite",
   "version": "0.1.0",
   "description": "Minimal library for alerts built using react and react-transitions",
-  "main": "src/index.js",
-  "style": "dist/main.css",
+  "main": "dist/index.min.js",
+  "style": "dist/index.min.css",
   "repository": "git@github.com:reactiness/react-alerts-lite.git",
   "author": "Geoff Whitehead",
   "license": "MIT",
@@ -62,9 +62,9 @@
     "webpack-cli": "^2.0.13",
     "webpack-dev-server": "^3.1.1"
   },
-  "peer-dependencies": {
-    "react": "^16.2.0",
-    "react-dom": "^16.2.0"
+  "peerDependencies": {
+    "react": "16.x",
+    "react-dom": "16.x"
   },
   "dependencies": {
     "react-transition-group": "^2.2.1"

--- a/package.json
+++ b/package.json
@@ -66,8 +66,8 @@
     "webpack-dev-server": "^3.1.1"
   },
   "peerDependencies": {
-    "react": "16.x",
-    "react-dom": "16.x"
+    "react": ">=15.0.0",
+    "react-dom": ">=15.0.0"
   },
   "dependencies": {
     "react-transition-group": "^2.2.1"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,8 +1,16 @@
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const OptimizeCSSAssetsPlugin = require("optimize-css-assets-webpack-plugin");
 const UglifyJsPlugin = require("uglifyjs-webpack-plugin");
+const path = require("path");
 
 module.exports = {
+  output: {
+    filename: "index.min.js",
+    libraryTarget: "umd",
+    library: "ReactAlertsLite",
+    path: path.resolve(__dirname, "dist")
+  },
+  externals: ["react", "react-dom", "prop-types"],
   optimization: {
     minimizer: [
       new UglifyJsPlugin({
@@ -15,7 +23,7 @@ module.exports = {
   },
   plugins: [
     new MiniCssExtractPlugin({
-      filename: "[name].css",
+      filename: "index.min.css",
       chunkFilename: "[id].css"
     })
   ],


### PR DESCRIPTION
When importing the library from another, there are some issues that I think revolve around the use of ES6+ constructs.

I think the typical way of publishing for libraries is to make the code point to the `/dist/index.min.js` bundle instead of pointing at `/src/index.js`.